### PR TITLE
Creates .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/CHANGELOG.md export-ignore
+/CONTRIBUTING.md export-ignore
+/phpunit.xml export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This .gitattributes file will inform composer which files are not required to
run this software. These files will only be excluded when composer is ran
with the ```--prefer-dist``` argument, which is normally ran in production.