### PR TITLE
Bump version constant

### DIFF
--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -27,7 +27,7 @@ class Stripe
      *
      * @var string
      */
-    const VERSION = '1.1.0';
+    const VERSION = '2.0.0';
 
     /**
      * The Config repository instance.


### PR DESCRIPTION
The version constant in Stripe.php has not been updated to reflect version 2.0.0