### PR TITLE
Fix __call method to work with Mockery

### DIFF
--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -187,7 +187,7 @@ class Stripe
      * @param  array  $parameters
      * @return \Cartalyst\Stripe\Api\ApiInterface
      */
-    public function __call($method, array $parameters = [])
+    public function __call($method, array $parameters)
     {
         if ($this->isIteratorRequest($method)) {
             $apiInstance = $this->getApiInstance(substr($method, 0, -8));


### PR DESCRIPTION
It is not currently possible to mock the Stripe class using Mockery, due to the method signature of `__call`. Mockery assumes a standard signature of `($method, $args)` without the default array syntax.

The current method signature of `__call` causes the creation of a mock to fail with the error:
```
Declaration of Mockery_1_Cartalyst_Stripe_Stripe::__call() should be compatible with Cartalyst\Stripe\Stripe::__call($method, array $parameters = Array)
```
As the `$parameters` parameter will always be an array anyway, the default value is superfluous and can be removed.