### PR TITLE
Use guzzle's retry middleware

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -27,7 +27,9 @@ use Cartalyst\Stripe\Utility;
 use Cartalyst\Stripe\ConfigInterface;
 use Psr\Http\Message\RequestInterface;
 use Cartalyst\Stripe\Exception\Handler;
+use Psr\Http\Message\ResponseInterface;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\TransferException;
 
 abstract class Api implements ApiInterface
 {
@@ -188,6 +190,12 @@ abstract class Api implements ApiInterface
                 ->withHeader('User-Agent', 'Cartalyst-Stripe/'.$config->getVersion())
                 ->withHeader('Authorization', 'Basic '.base64_encode($config->getApiKey()))
             ;
+        }));
+
+        $stack->push(Middleware::retry(function ($retries, RequestInterface $request, ResponseInterface $response = null, TransferException $exception = null) {
+            return $retries < 3 && ($exception instanceof ConnectException || ($response && $response->getStatusCode() >= 500));
+        }, function ($retries) {
+            return (int) pow(2, $retries) * 1000;
         }));
 
         return $stack;


### PR DESCRIPTION
I've noticed a few stripe error 500s on my applications, so using guzzle's native retry middleware would be cool. Unfortunately, this package is not architected in a way where by I could actually set a custom guzzle client, so I've come here with a PR that adds the retry middleware.

I've set this up to work exactly like guzzle 3's backoff plugin used to work.

Basically, retry 5xx responses, or totally failed requests, upto 3 times using an exponential backoff strategy (1 second, 2 seconds, 4 seconds).