### PR TITLE
Added rawOutput param on StripeException object

### DIFF
--- a/src/Exception/Handler.php
+++ b/src/Exception/Handler.php
@@ -76,7 +76,9 @@ class Handler
 
         $statusCode = $response->getStatusCode();
 
-        $error = json_decode($response->getBody(true), true)['error'];
+        $rawOutput = json_decode($response->getBody(true), true);
+
+        $error = isset($rawOutput['error']) ? $rawOutput['error'] : [];
 
         $errorCode = isset($error['code']) ? $error['code'] : null;
 
@@ -87,7 +89,7 @@ class Handler
         $missingParameter = isset($error['param']) ? $error['param'] : null;
 
         $this->handleException(
-            $message, $statusCode, $errorType, $errorCode, $missingParameter
+            $message, $statusCode, $errorType, $errorCode, $missingParameter, $rawOutput
         );
     }
 
@@ -102,7 +104,7 @@ class Handler
      * @return void
      * @throws \Cartalyst\Stripe\Exception\StripeException
      */
-    protected function handleException($message, $statusCode, $errorType, $errorCode, $missingParameter)
+    protected function handleException($message, $statusCode, $errorType, $errorCode, $missingParameter, $rawOutput)
     {
         if ($statusCode === 400 && $errorCode === 'rate_limit') {
             $class = 'ApiLimitExceeded';
@@ -123,6 +125,7 @@ class Handler
         $instance->setErrorCode($errorCode);
         $instance->setErrorType($errorType);
         $instance->setMissingParameter($missingParameter);
+        $instance->setRawOutput($rawOutput);
 
         throw $instance;
     }

--- a/src/Exception/StripeException.php
+++ b/src/Exception/StripeException.php
@@ -44,6 +44,13 @@ class StripeException extends \Exception
     protected $missingParameter;
 
     /**
+     * The raw output returned by Stripe in case of exception.
+     *
+     * @var string
+     */
+    protected $rawOutput;
+
+    /**
      * Returns the error type returned by Stripe.
      *
      * @return string
@@ -108,6 +115,29 @@ class StripeException extends \Exception
     public function setMissingParameter($missingParameter)
     {
         $this->missingParameter = $missingParameter;
+
+        return $this;
+    }
+
+    /**
+     * Returns raw output returned by Stripe in case of exception.
+     *
+     * @return string
+     */
+    public function getRawOutput()
+    {
+        return $this->rawOutput;
+    }
+
+    /**
+     * Sets the raw output parameter returned by Stripe in case of exception.
+     *
+     * @param  string  $rawOutput
+     * @return $this
+     */
+    public function setRawOutput($rawOutput)
+    {
+        $this->rawOutput = $rawOutput;
 
         return $this;
     }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -56,7 +56,7 @@ class Utility
         $currencies = [
             'BIF', 'DJF', 'JPY', 'KRW', 'PYG',
             'VND', 'XAF', 'XPF', 'CLP', 'GNF',
-            'KMF', 'MGA', 'RWF', 'VUV', 'XOF',
+            'KMF', 'MGA', 'RWF', 'VUV', 'XOF', 'USD',
         ];
 
         return ! $hasCurrency || ($hasCurrency && ! in_array($parameters['currency'], $currencies));

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -56,9 +56,9 @@ class Utility
         $currencies = [
             'BIF', 'DJF', 'JPY', 'KRW', 'PYG',
             'VND', 'XAF', 'XPF', 'CLP', 'GNF',
-            'KMF', 'MGA', 'RWF', 'VUV', 'XOF', 'USD',
+            'KMF', 'MGA', 'RWF', 'VUV', 'XOF',
         ];
 
-        return $hasCurrency && ! in_array($parameters['currency'], $currencies);
+        return !$hasCurrency && ! in_array($parameters['currency'], $currencies);
     }
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -56,7 +56,7 @@ class Utility
         $currencies = [
             'BIF', 'DJF', 'JPY', 'KRW', 'PYG',
             'VND', 'XAF', 'XPF', 'CLP', 'GNF',
-            'KMF', 'MGA', 'RWF', 'VUV', 'XOF', 'USD',
+            'KMF', 'MGA', 'RWF', 'VUV', 'XOF',
         ];
 
         return ! $hasCurrency || ($hasCurrency && ! in_array($parameters['currency'], $currencies));

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -56,9 +56,9 @@ class Utility
         $currencies = [
             'BIF', 'DJF', 'JPY', 'KRW', 'PYG',
             'VND', 'XAF', 'XPF', 'CLP', 'GNF',
-            'KMF', 'MGA', 'RWF', 'VUV', 'XOF',
+            'KMF', 'MGA', 'RWF', 'VUV', 'XOF', 'USD',
         ];
 
-        return ! $hasCurrency || ($hasCurrency && ! in_array($parameters['currency'], $currencies));
+        return $hasCurrency && ! in_array($parameters['currency'], $currencies);
     }
 }

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -59,6 +59,6 @@ class Utility
             'KMF', 'MGA', 'RWF', 'VUV', 'XOF',
         ];
 
-        return !$hasCurrency && ! in_array($parameters['currency'], $currencies);
+        return !$hasCurrency || ($hasCurrency && ! in_array($parameters['currency'], $currencies));
     }
 }


### PR DESCRIPTION
Added a way to pass raw output of Stripe exception via Handler to the Exception object as rawOutput parameter in order to handle exceptions that carry additional data like charge identifier, etc.