### PR TITLE
Clarifying the `amount` param's value

### DIFF
--- a/usage/charges/create.md
+++ b/usage/charges/create.md
@@ -39,7 +39,7 @@ To charge a credit card, you need to create a new charge object. If your API key
             <td>true</td>
             <td>number</td>
             <td>null</td>
-            <td>A positive amount representing how much to charge the card.</td>
+            <td>A positive amount representing how much to charge the card. Note that this should be a dollar amount, and will automatically be converted in to cents for you before being transmitted to Stripe.</td>
         </tr>
         <tr>
             <td>currency</td>


### PR DESCRIPTION
Stripe's PHP library ([stripe/stripe-php](https://github.com/stripe/stripe-php)) expects the `amount` param's value to be in cents, but this library expects the value to be in dollars and will automatically convert it to cents. This discrepancy is not clear, so I think it should be explicitly stated in the documentation.