### PR TITLE
Avoid the unsafe getenv function

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -76,9 +76,28 @@ class Config implements ConfigInterface
     {
         $this->setVersion($version);
 
-        $this->setApiKey($apiKey ?: getenv('STRIPE_API_KEY'));
+        $this->setApiKey($apiKey ?: self::getEnvVariable('STRIPE_API_KEY', ''));
 
-        $this->setApiVersion($apiVersion ?: getenv('STRIPE_API_VERSION') ?: '2017-06-05');
+        $this->setApiVersion($apiVersion ?: self::getEnvVariable('STRIPE_API_VERSION', '2017-06-05'));
+    }
+
+    /**
+     * @param string      $name
+     * @param string|null $default
+     *
+     * @return string|null
+     */
+    private static function getEnvVariable($name, $default = null)
+    {
+        if (isset($_SERVER[$name])) {
+            return (string) $_SERVER[$name];
+        }
+
+        if (PHP_SAPI === 'cli' && ($value = getenv($name)) !== false) {
+            return (string) $value;
+        }
+
+        return $default;
     }
 
     /**


### PR DESCRIPTION
#### TLDR: `getenv` is not thread safe!

Obviously this doesn't matter when this library is using with composer running in the console, but it does matter when this code is running on a web server. The `genv` and `putenv` functions are not threadsafe, so environment variables set in one thread using `putenv` may leak into another via `getenv`.

This not just a "theoretical" bug. It actually happens in real apps and serves, and was the result of hundreds of bug reports on the Laravel framework over the years, where people were confused by variables not being what they expected!

---

EDIT: In order to minimize breakage, for CLI apps, I've allowed to still read from `getenv` for that.