### PR TITLE
Account ids and idempotency keys can be null

### DIFF
--- a/src/Api/ApiInterface.php
+++ b/src/Api/ApiInterface.php
@@ -47,7 +47,7 @@ interface ApiInterface
     /**
      * Sets the idempotency key.
      *
-     * @param  string  $idempotencyKey
+     * @param  string|null  $idempotencyKey
      * @return $this
      */
     public function idempotent($idempotencyKey);

--- a/src/Config.php
+++ b/src/Config.php
@@ -46,14 +46,14 @@ class Config implements ConfigInterface
     /**
      * The idempotency key.
      *
-     * @var string
+     * @var string|null
      */
     protected $idempotencyKey;
 
     /**
      * The managed account id.
      *
-     * @var string
+     * @var string|null
      */
     protected $accountId;
 
@@ -175,7 +175,7 @@ class Config implements ConfigInterface
     /**
      * Returns the managed account id.
      *
-     * @return string
+     * @return string|null
      */
     public function getAccountId()
     {
@@ -185,7 +185,7 @@ class Config implements ConfigInterface
     /**
      * Sets the managed account id.
      *
-     * @param  string  $accountId
+     * @param  string|null  $accountId
      * @return $this
      */
     public function setAccountId($accountId)

--- a/src/ConfigInterface.php
+++ b/src/ConfigInterface.php
@@ -70,14 +70,14 @@ interface ConfigInterface
     /**
      * Returns the idempotency key.
      *
-     * @return string
+     * @return string|null
      */
     public function getIdempotencyKey();
 
     /**
      * Sets the idempotency key.
      *
-     * @param  string  $idempotencyKey
+     * @param  string|null  $idempotencyKey
      * @return $this
      */
     public function setIdempotencyKey($idempotencyKey);

--- a/src/Stripe.php
+++ b/src/Stripe.php
@@ -151,7 +151,7 @@ class Stripe
     /**
      * Sets the idempotency key.
      *
-     * @param  string  $idempotencyKey
+     * @param  string|null  $idempotencyKey
      * @return $this
      */
     public function idempotent($idempotencyKey)
@@ -164,7 +164,7 @@ class Stripe
     /**
      * Sets the account id.
      *
-     * @param  string  $accountId
+     * @param  string|null  $accountId
      * @return $this
      */
     public function accountId($accountId)


### PR DESCRIPTION
This is not a BC break, but a bug fix to the phpdoc. Indeed, I call the idempotent function with `null` in order to reset it to the initial state.