### PR TITLE
Small patch to needsAmountConversion utility function.

### DIFF
--- a/src/Utility.php
+++ b/src/Utility.php
@@ -61,6 +61,6 @@ class Utility
             'KMF', 'MGA', 'RWF', 'VUV', 'XOF',
         ];
 
-        return ! $hasCurrency || ($hasCurrency && ! in_array($parameters['currency'], $currencies));
+        return ! $hasCurrency || ($hasCurrency && ! in_array(strtoupper($parameters['currency']), $currencies));
     }
 }


### PR DESCRIPTION
Since I experienced problem when paying with JPY, I propose this change.

I was always sending 'jpy' in lower case and it ended up again multiplying by 100. 

PHP function in_array is case-sensitive.

This is addition to: https://github.com/cartalyst/stripe/pull/60 .