### PR TITLE
Allow Refunds for Payment Intents

### DIFF
--- a/src/Api/Refunds.php
+++ b/src/Api/Refunds.php
@@ -32,10 +32,14 @@ class Refunds extends Api
      */
     public function create($paymentId, $amount = null, array $parameters = [])
     {
-        $paymentType = substr($paymentId, 0, 2) == 'ch' ? 'charge' : 'payment_intent';
-        $parameters = array_merge($parameters, [$paymentType => $paymentId, 'amount' => $amount]);
+        $paymentType = $this->getPaymentType($paymentId);
 
-        return $this->_post("refunds", $parameters);
+        $parameters = array_merge($parameters, [
+            'amount'     => $amount,
+            $paymentType => $paymentId,
+        ]);
+
+        return $this->_post('refunds', $parameters);
     }
 
     /**
@@ -51,7 +55,7 @@ class Refunds extends Api
             return $this->_get("refunds/{$chargeId}");
         }
 
-        return $this->_get("charges/{$chargeId}/refunds/{$refundId}");
+        return $this->_get("refunds/{$refundId}");
     }
 
     /**
@@ -77,13 +81,25 @@ class Refunds extends Api
      */
     public function all($paymentId = null, array $parameters = [])
     {
-        if($paymentId)
-        {
-            $paymentType = substr($paymentId, 0, 2) == 'ch' ? 'charge' : 'payment_intent';
+        if ($paymentId) {
+            $paymentType = $this->getPaymentType($paymentId);
 
-            $parameters = array_merge($parameters, [$paymentType => $paymentId]);
+            $parameters = array_merge($parameters, [
+                $paymentType => $paymentId,
+            ]);
         }
 
         return $this->_get('refunds', $parameters);
+    }
+
+    /**
+     * Returns the payment type for the provided payment id.
+     *
+     * @param  string  $paymentId
+     * @return void
+     */
+    private function getPaymentType(string $paymentId)
+    {
+        return substr($paymentId, 0, 2) === 'ch' ? 'charge' : 'payment_intent';
     }
 }

--- a/src/Api/Refunds.php
+++ b/src/Api/Refunds.php
@@ -23,63 +23,48 @@ namespace Cartalyst\Stripe\Api;
 class Refunds extends Api
 {
     /**
-     * Creates a new refund for the given charge.
+     * Creates a new refund.
      *
-     * @param  string  $chargeId
-     * @param  int  $amount
      * @param  array  $parameters
      * @return array
      */
-    public function create($chargeId, $amount = null, array $parameters = [])
+    public function create(array $parameters = [])
     {
-        $parameters = array_merge($parameters, array_filter(compact('amount')));
-
-        return $this->_post("charges/{$chargeId}/refunds", $parameters);
+        return $this->_post("refunds", $parameters);
     }
 
     /**
-     * Retrieves an existing refund from the given charge.
+     * Retrieves an existing refund.
      *
-     * @param  string  $chargeId
      * @param  string|null  $refundId
      * @return array
      */
-    public function find($chargeId, $refundId = null)
+    public function find($refundId)
     {
-        if (! $refundId) {
-            return $this->_get("refunds/{$chargeId}");
-        }
-
-        return $this->_get("charges/{$chargeId}/refunds/{$refundId}");
+        return $this->_get("refunds/{$refundId}");
     }
 
     /**
-     * Updates an existing refund on the given charge.
+     * Updates an existing refund.
      *
-     * @param  string  $chargeId
      * @param  string  $refundId
      * @param  array  $parameters
      * @return array
      */
-    public function update($chargeId, $refundId, array $parameters = [])
+    public function update($refundId, array $parameters = [])
     {
-        return $this->_post("charges/{$chargeId}/refunds/{$refundId}", $parameters);
+        return $this->_post("refunds/{$refundId}", $parameters);
     }
 
     /**
      * Lists all the refunds of the current Stripe account
-     * or lists all the refunds for the given charge.
+     * or list all refunds for a given charge / payment intent.
      *
-     * @param  string|null  $chargeId
      * @param  array  $parameters
      * @return array
      */
-    public function all($chargeId = null, array $parameters = [])
+    public function all(array $parameters = [])
     {
-        if (! $chargeId) {
-            return $this->_get('refunds', $parameters);
-        }
-
-        return $this->_get("charges/{$chargeId}/refunds", $parameters);
+        return $this->_get('refunds', $parameters);
     }
 }

--- a/src/Api/Refunds.php
+++ b/src/Api/Refunds.php
@@ -23,48 +23,67 @@ namespace Cartalyst\Stripe\Api;
 class Refunds extends Api
 {
     /**
-     * Creates a new refund.
+     * Creates a new refund for the given charge or payment intent.
      *
+     * @param  string  $paymentId
+     * @param  int  $amount
      * @param  array  $parameters
      * @return array
      */
-    public function create(array $parameters = [])
+    public function create($paymentId, $amount = null, array $parameters = [])
     {
+        $paymentType = substr($paymentId, 0, 2) == 'ch' ? 'charge' : 'payment_intent';
+        $parameters = array_merge($parameters, [$paymentType => $paymentId, 'amount' => $amount]);
+
         return $this->_post("refunds", $parameters);
     }
 
     /**
-     * Retrieves an existing refund.
+     * Retrieves an existing refund from the given charge.
      *
+     * @param  string  $chargeId
      * @param  string|null  $refundId
      * @return array
      */
-    public function find($refundId)
+    public function find($chargeId, $refundId = null)
     {
-        return $this->_get("refunds/{$refundId}");
+        if (! $refundId) {
+            return $this->_get("refunds/{$chargeId}");
+        }
+
+        return $this->_get("charges/{$chargeId}/refunds/{$refundId}");
     }
 
     /**
      * Updates an existing refund.
      *
+     * @param  string  $chargeId
      * @param  string  $refundId
      * @param  array  $parameters
      * @return array
      */
-    public function update($refundId, array $parameters = [])
+    public function update($chargeId, $refundId, array $parameters = [])
     {
         return $this->_post("refunds/{$refundId}", $parameters);
     }
 
     /**
      * Lists all the refunds of the current Stripe account
-     * or list all refunds for a given charge / payment intent.
+     * or lists all the refunds for the given charge or payment intent.
      *
+     * @param  string|null  $paymentId
      * @param  array  $parameters
      * @return array
      */
-    public function all(array $parameters = [])
+    public function all($paymentId = null, array $parameters = [])
     {
+        if($paymentId)
+        {
+            $paymentType = substr($paymentId, 0, 2) == 'ch' ? 'charge' : 'payment_intent';
+
+            $parameters = array_merge($parameters, [$paymentType => $paymentId]);
+        }
+
         return $this->_get('refunds', $parameters);
     }
 }

--- a/tests/Api/RefundsTest.php
+++ b/tests/Api/RefundsTest.php
@@ -26,13 +26,13 @@ use Cartalyst\Stripe\Exception\NotFoundException;
 class RefundsTest extends FunctionalTestCase
 {
     /** @test */
-    public function it_can_create_a_refund_from_charge()
+    public function it_can_create_a_refund()
     {
         $customer = $this->createCustomer();
 
         $charge = $this->createCharge($customer['id']);
 
-        $refund = $this->stripe->refunds()->create(['charge' => $charge['id']]);
+        $refund = $this->stripe->refunds()->create($charge['id']);
 
         $charge = $this->stripe->charges()->find($charge['id']);
 
@@ -47,7 +47,7 @@ class RefundsTest extends FunctionalTestCase
 
         $charge = $this->createCharge($customer['id']);
 
-        $refund = $this->stripe->refunds()->create(['charge' => $charge['id'], 'amount' => 20.00]);
+        $refund = $this->stripe->refunds()->create($charge['id'], 20.00);
 
         $charge = $this->stripe->charges()->find($charge['id']);
 
@@ -62,7 +62,24 @@ class RefundsTest extends FunctionalTestCase
 
         $charge = $this->createCharge($customer['id']);
 
-        $refund = $this->stripe->refunds()->create(['charge' => $charge['id']]);
+        $refund = $this->stripe->refunds()->create($charge['id']);
+
+        $refund = $this->stripe->refunds()->find($charge['id'], $refund['id']);
+
+        $charge = $this->stripe->charges()->find($charge['id']);
+
+        $this->assertTrue($charge['refunded']);
+        $this->assertSame(5049, $refund['amount']);
+    }
+
+    /** @test */
+    public function it_can_find_a_refund_without_passing_the_charge_id()
+    {
+        $customer = $this->createCustomer();
+
+        $charge = $this->createCharge($customer['id']);
+
+        $refund = $this->stripe->refunds()->create($charge['id']);
 
         $refund = $this->stripe->refunds()->find($refund['id']);
 
@@ -79,7 +96,9 @@ class RefundsTest extends FunctionalTestCase
 
         $customer = $this->createCustomer();
 
-        $this->stripe->refunds()->find(time().rand());
+        $charge = $this->createCharge($customer['id']);
+
+        $this->stripe->refunds()->find($charge['id'], time().rand());
     }
 
     /** @test */
@@ -89,32 +108,14 @@ class RefundsTest extends FunctionalTestCase
 
         $charge = $this->createCharge($customer['id']);
 
-        $refund = $this->stripe->refunds()->create(['charge' => $charge['id']]);
+        $refund = $this->stripe->refunds()->create($charge['id']);
 
-        $refund = $this->stripe->refunds()->update($refund['id'], [
+        $refund = $this->stripe->refunds()->update($charge['id'], $refund['id'], [
             'metadata' => [ 'reason' => 'Refunded the payment.' ]
         ]);
 
         $this->assertSame(5049, $refund['amount']);
         $this->assertSame('Refunded the payment.', $refund['metadata']['reason']);
-    }
-
-    /** @test */
-    public function it_can_retrieve_all_refunds_for_a_charge()
-    {
-        $customer = $this->createCustomer();
-
-        $charge1 = $this->createCharge($customer['id']);
-        $charge2 = $this->createCharge($customer['id']);
-
-        $this->stripe->refunds()->create(['charge' => $charge1['id']]);
-        $this->stripe->refunds()->create(['charge' => $charge2['id']]);
-
-        $refunds = $this->stripe->refunds()->all(['charge' => $charge1['id']]);
-
-        $this->assertNotEmpty($refunds['data']);
-        $this->assertCount(1, $refunds['data']);
-        $this->assertIsArray($refunds['data']);
     }
 
     /** @test */
@@ -125,8 +126,26 @@ class RefundsTest extends FunctionalTestCase
         $charge1 = $this->createCharge($customer['id']);
         $charge2 = $this->createCharge($customer['id']);
 
-        $this->stripe->refunds()->create(['charge' => $charge1['id']]);
-        $this->stripe->refunds()->create(['charge' => $charge2['id']]);
+        $this->stripe->refunds()->create($charge1['id']);
+        $this->stripe->refunds()->create($charge2['id']);
+
+        $refunds = $this->stripe->refunds()->all($charge1['id']);
+
+        $this->assertNotEmpty($refunds['data']);
+        $this->assertCount(1, $refunds['data']);
+        $this->assertIsArray($refunds['data']);
+    }
+
+    /** @test */
+    public function it_can_retrieve_all_refunds_without_passing_the_charge_id()
+    {
+        $customer = $this->createCustomer();
+
+        $charge1 = $this->createCharge($customer['id']);
+        $charge2 = $this->createCharge($customer['id']);
+
+        $this->stripe->refunds()->create($charge1['id']);
+        $this->stripe->refunds()->create($charge2['id']);
 
         $refunds = $this->stripe->refunds()->all();
 


### PR DESCRIPTION
modified tests for Refunds so that they are working for the new implementation.

This does break backwards compatibility since the methods do not accept chargeId as a parameter anymore bur rather accept it in an array of parameters.