### PR TITLE
Update Sessions.php

### DIFF
--- a/src/Api/Checkout/Sessions.php
+++ b/src/Api/Checkout/Sessions.php
@@ -50,4 +50,16 @@ class Sessions extends AbstractApi
     {
         return $this->_get("checkout/sessions/{$sessionId}");
     }
+
+    /**
+     * Retrieves line items for an existing session.
+     *
+     * @param string $sessionId
+     *
+     * @return \Cartalyst\Stripe\HttpClient\Message\ApiResponse
+     */
+    public function lineItems(string $sessionId): ApiResponse
+    {
+        return $this->_get("checkout/sessions/{$sessionId}/line_items");
+    }
 }


### PR DESCRIPTION
Adds the ability to retrieve line items for a checkout session. We are currently using version 2.0 through stripe/laravel package, version 12. This probably should be updated throughout all the major versions.