### PR TITLE
Update Utility.php

### DIFF
--- a/src/Utility.php
+++ b/src/Utility.php
@@ -31,6 +31,12 @@ class Utility
     public static function prepareParameters(array $parameters)
     {
         $toConvert = [ 'amount', 'price' ];
+        
+        $bypassConversion = false;
+        if (isset($parameters['conversion']) && !$parameters['conversion']) {
+            $bypassConversion = true;
+            unset($parameters['conversion']);
+        }
 
         if (self::needsAmountConversion($parameters)) {
             if ($converter = Stripe::getAmountConverter()) {


### PR DESCRIPTION
Create Stripe InvoiceItem accept price identifier in "price" attributes but with the converter on price and amount, this identifier is transformed to integer and not correspond to a StripePriceId

I propose to use a boolean attribute "conversion" to bypass this conversion if needed like : 

`
Stripe::invoiceItems()->create('cus_ndfjshjfdhf45456', [
		'price'     => 'price_hjhghdqezei1545',
		'conversion'  => false,
]);
`
