### PR TITLE
Refunds : invert charge/payment_intent token resolution

### DIFF
--- a/src/Api/Refunds.php
+++ b/src/Api/Refunds.php
@@ -100,6 +100,6 @@ class Refunds extends Api
      */
     private function getPaymentType(string $paymentId)
     {
-        return substr($paymentId, 0, 2) === 'ch' ? 'charge' : 'payment_intent';
+        return substr($paymentId, 0, 2) === 'pi' ? 'payment_intent' : 'charge';
     }
 }


### PR DESCRIPTION
Refund payment using a `py_` token.
See [Issue #216](https://github.com/cartalyst/stripe/issues/216)